### PR TITLE
Add back support for JGI LR-MG

### DIFF
--- a/src/mutts/retriever.py
+++ b/src/mutts/retriever.py
@@ -16,6 +16,7 @@ class MetadataRetriever:
     USER_FACILITY_DICT: Dict[str, str] = {
         "emsl": "emsl_data",
         "jgi_mg": "jgi_mg_data",
+        "jgi_mg_lr": "jgi_mg_lr_data",
         "jgi_mt": "jgi_mt_data",
     }
 
@@ -83,7 +84,12 @@ class MetadataRetriever:
 
         # Find non-user-facility keys (ie, plant_associated, water, etc)
         all_keys_data = response["metadata_submission"]["sampleData"]
-        user_facility_keys = ["emsl_data", "jgi_mg_data", "jgi_mt_data"]
+        user_facility_keys = [
+            "emsl_data",
+            "jgi_mg_data",
+            "jgi_mg_lr_data",
+            "jgi_mt_data",
+        ]
         sample_data_keys = [
             key for key in all_keys_data if key not in user_facility_keys
         ]


### PR DESCRIPTION
Apologies, during our refactor of the code in this repo (in #76) it appears that a section of code (from what used to be `etl.py`) was overlooked (handler for JGI LR-MG) and was dropped from the codebase.

I looked through the previous etl.py script, and saw that the piece of code that was dropped was the PR @cristina-stonepedraza added here: #70, so in this PR i'm simply adding that functionality back in.

It's also necessary for this code to get merged in for me to work on https://github.com/microbiomedata/metadata-for-user-facility-template-transformations/issues/69