### PR TITLE
Map `biosafety_mat_cat` to appropriate column in JGI MG/MT/LR mappers

### DIFF
--- a/input-files/jgi_mg_header.json
+++ b/input-files/jgi_mg_header.json
@@ -66,7 +66,8 @@
         "1": "List any organisms known or suspected to grow in co-culture, as well as estimated % of the organism in that culture."
     },
     "Biosafety Material Category*": {
-        "1": "Metagenome (Environmental) or Metagenome (Host-associated)"
+        "1": "Metagenome (Environmental) or Metagenome (Host-associated)",
+        "sub_port_mapping": "biosafety_mat_cat"
     },
     "Sample Isolation Method*": {
         "1": "Describe the method/protocol/kit used to extract DNA/RNA.",

--- a/input-files/jgi_mt_header.json
+++ b/input-files/jgi_mt_header.json
@@ -66,7 +66,8 @@
         "1": "List any organisms known or suspected to grow in co-culture, as well as estimated % of the organism in that culture."
     },
     "Biosafety Material Category*": {
-        "1": "Metagenome (Environmental) or Metagenome (Host-associated)"
+        "1": "Metagenome (Environmental) or Metagenome (Host-associated)",
+        "sub_port_mapping": "biosafety_mat_cat"
     },
     "Sample Isolation Method*": {
         "1": "Describe the method/protocol/kit used to extract DNA/RNA.",


### PR DESCRIPTION
Make sure we are pulling in values from the `biosafety_mat_cat` slot column under "Biosafety Material Category*" appropriately.