### PR TITLE
Fixes to JGI v15 template mapper files based on validation report

### DIFF
--- a/input-files/jgi_mg_header_v15.json
+++ b/input-files/jgi_mg_header_v15.json
@@ -146,5 +146,21 @@
         "1": "Country or ocean where the sample was collected.",
         "2": "USA",
         "sub_port_mapping": "country_name"
+    },
+    "Sample Contact Name*": {
+        "1": "Prefilled",
+        "2": "John Jones"
+    },
+    "Seq Project PI Name (No edit)": {
+        "1": "Prefilled",
+        "2": "Jane Johnson"
+    },
+    "Tissue Contact Name": {
+        "1": "Prefilled",
+        "2": "Jordan James"
+    },
+    "Proposal ID (No edit)": {
+        "1": "Prefilled",
+        "2": "504000"
     }
 }

--- a/input-files/jgi_mt_header_v15.json
+++ b/input-files/jgi_mt_header_v15.json
@@ -146,5 +146,21 @@
         "1": "Country or ocean where the sample was collected.",
         "2": "USA",
         "sub_port_mapping": "country_name"
+    },
+    "Sample Contact Name*": {
+        "1": "Prefilled",
+        "2": "John Jones"
+    },
+    "Seq Project PI Name (No edit)": {
+        "1": "Prefilled",
+        "2": "Jane Johnson"
+    },
+    "Tissue Contact Name": {
+        "1": "Prefilled",
+        "2": "Jordan James"
+    },
+    "Proposal ID (No edit)": {
+        "1": "Prefilled",
+        "2": "504000"
     }
 }


### PR DESCRIPTION
Based on the validation report from the JGI POC (details captured in https://github.com/microbiomedata/metadata-for-user-facility-template-transformations/issues/49#issuecomment-3548707530), we have made the following fixes to the mapper templates:

- [x] Add example values from v15 template as row 3 in the output sheet
- [x] Add missing dot (`.`) to the end of column header "Plate location (well #)* required if samples provided in a plate."
- [x] Add following missing columns back into v15 template mappers – "Sample Contact Name*", "Seq Project PI Name (No edit)", "Tissue Contact Name", "Proposal ID (No edit)"