### PR TITLE
JGI template column name change and `dnase` slot translation for JGI MG LR

### DIFF
--- a/input-files/jgi_mg_header.json
+++ b/input-files/jgi_mg_header.json
@@ -15,7 +15,7 @@
         "1": "List the sample's Globally Unique Identifier, if available. More details are available on the \"instructions\" tab.",
         "sub_port_mapping": "source_mat_id"
     },
-    "Sample Name": {
+    "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
         "sub_port_mapping": "jgi_sample_name"
     },

--- a/input-files/jgi_mg_header_v15.json
+++ b/input-files/jgi_mg_header_v15.json
@@ -19,7 +19,7 @@
         "2": "igsn:IEBWE008U",
         "sub_port_mapping": "source_mat_id"
     },
-    "Sample Name": {
+    "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
         "2": "JGI_pond_041618",
         "sub_port_mapping": "jgi_sample_name"
@@ -152,7 +152,7 @@
         "2": "USA",
         "sub_port_mapping": "country_name"
     },
-    "Sample Contact Name*": {
+    "Sample Contact Name": {
         "1": "Prefilled",
         "2": "John Jones"
     },

--- a/input-files/jgi_mg_header_v16.json
+++ b/input-files/jgi_mg_header_v16.json
@@ -19,7 +19,7 @@
         "2": "igsn:IEBWE008U",
         "sub_port_mapping": "source_mat_id"
     },
-    "Sample Name": {
+    "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
         "2": "JGI_pond_041618",
         "sub_port_mapping": "jgi_sample_name"
@@ -156,7 +156,7 @@
         "2": "USA",
         "sub_port_mapping": "country_name"
     },
-    "Sample Contact Name*": {
+    "Sample Contact Name": {
         "1": "Prefilled",
         "2": "John Jones",
         "sub_port_mapping": "jgi_sample_contact"

--- a/input-files/jgi_mt_header.json
+++ b/input-files/jgi_mt_header.json
@@ -15,7 +15,7 @@
         "1": "List the sample's Globally Unique Identifier, if available. More details are available on the \"instructions\" tab.",
         "sub_port_mapping": "source_mat_id"
     },
-    "Sample Name": {
+    "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
         "sub_port_mapping": "jgi_sample_name"
     },

--- a/input-files/jgi_mt_header_v15.json
+++ b/input-files/jgi_mt_header_v15.json
@@ -19,7 +19,7 @@
         "2": "igsn:IEBWE008U",
         "sub_port_mapping": "source_mat_id"
     },
-    "Sample Name": {
+    "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
         "2": "JGI_pond_041618",
         "sub_port_mapping": "jgi_sample_name"
@@ -152,7 +152,7 @@
         "2": "USA",
         "sub_port_mapping": "country_name"
     },
-    "Sample Contact Name*": {
+    "Sample Contact Name": {
         "1": "Prefilled",
         "2": "John Jones"
     },

--- a/input-files/jgi_mt_header_v16.json
+++ b/input-files/jgi_mt_header_v16.json
@@ -19,7 +19,7 @@
         "2": "igsn:IEBWE008U",
         "sub_port_mapping": "source_mat_id"
     },
-    "Sample Name": {
+    "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
         "2": "JGI_pond_041618",
         "sub_port_mapping": "jgi_sample_name"
@@ -156,7 +156,7 @@
         "2": "USA",
         "sub_port_mapping": "country_name"
     },
-    "Sample Contact Name*": {
+    "Sample Contact Name": {
         "1": "Prefilled",
         "2": "John Jones",
         "sub_port_mapping": "jgi_sample_contact"


### PR DESCRIPTION
The below two issues have been addressed in this PR:

- [x] Rename column "Sample Contact Name*" from the JGI JSON mapper files to "Sample Contact Name" (i.e., remove '*')
- [x] The value translation in the `dnase` (slot)/"Was Sample DNAse treated?*" (column) needs to be applied when the UF value is "jgi_mg_lr" too