### PR TITLE
Update guidance text for few columns in v16 mappers

### DIFF
--- a/input-files/jgi_mg_header_v16.json
+++ b/input-files/jgi_mg_header_v16.json
@@ -98,17 +98,17 @@
         "sub_port_mapping": "dna_isolate_meth"
     },
     "Collection Year*": {
-        "1": "Year in which the sample was collected.",
+        "1": "Year in which the sample was collected. More details on the \"instructions\" tab.",
         "2": "2018",
         "sub_port_mapping": "collection_year"
     },
     "Collection Month*": {
-        "1": "Month in which the sample was collected. Use the full name of the month.",
+        "1": "Month in which the sample was collected. Use the full name of the month. More details on the \"instructions\" tab.",
         "2": "April",
         "sub_port_mapping": "collection_month_name"
     },
     "Collection Day*": {
-        "1": "Day on which the sample was collected.",
+        "1": "Day on which the sample was collected. More details on the \"instructions\" tab.",
         "2": "1",
         "sub_port_mapping": "collection_day"
     },

--- a/input-files/jgi_mt_header_v16.json
+++ b/input-files/jgi_mt_header_v16.json
@@ -98,17 +98,17 @@
         "sub_port_mapping": "rna_isolate_meth"
     },
     "Collection Year*": {
-        "1": "Year in which the sample was collected.",
+        "1": "Year in which the sample was collected. More details on the \"instructions\" tab.",
         "2": "2018",
         "sub_port_mapping": "collection_year"
     },
     "Collection Month*": {
-        "1": "Month in which the sample was collected. Use the full name of the month.",
+        "1": "Month in which the sample was collected. Use the full name of the month. More details on the \"instructions\" tab.",
         "2": "April",
         "sub_port_mapping": "collection_month_name"
     },
     "Collection Day*": {
-        "1": "Day on which the sample was collected.",
+        "1": "Day on which the sample was collected. More details on the \"instructions\" tab.",
         "2": "1",
         "sub_port_mapping": "collection_day"
     },


### PR DESCRIPTION
The guidance text (in row 2) for some columns – "Collection Year*", "Collection Month*" and "Collection Day*" was incomplete according to the example v16b template attached in here https://github.com/microbiomedata/metadata-for-user-facility-template-transformations/issues/49#issuecomment-3762432825