### PR TITLE
Format collection_year and collection_day as integers

### DIFF
--- a/src/mutts/retriever.py
+++ b/src/mutts/retriever.py
@@ -168,9 +168,9 @@ class MetadataRetriever:
             df["country_name"] = df["geo_loc_name"].str.split(":").str[0]
 
         if "collection_date" in df.columns:
-            df["collection_year"] = df["collection_date"].str.split("-").str[0]
+            df["collection_year"] = df["collection_date"].str.split("-").str[0].astype(int)
             df["collection_month"] = df["collection_date"].str.split("-").str[1]
-            df["collection_day"] = df["collection_date"].str.split("-").str[2]
+            df["collection_day"] = df["collection_date"].str.split("-").str[2].astype(int)
 
             # Safely map collection_month to month_name (account for NaN values)
             def get_month_name(month):


### PR DESCRIPTION
Fixes #104 

## Summary
- Convert `collection_year` and `collection_day` from zero-padded strings to integers in `retriever.py`
- Fixes day values displaying as `07` instead of `7` in the Excel output
- Eliminates Excel type conversion warning for the collection year column

## Test plan
- [x] Run mutts and verify collection_day values no longer have leading zeros
- [x] Open generated Excel file and confirm no yellow type conversion warning on collection_year
- [x] Verify collection_month (string-based month name) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)