### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Fetch all history for dynamic versioning
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -35,4 +35,4 @@ jobs:
         run: poetry build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```