### PR TITLE
Remove mapping between isotope_exposure and 'Isotope Label*'

### DIFF
--- a/input-files/jgi_mg_header.json
+++ b/input-files/jgi_mg_header.json
@@ -23,8 +23,7 @@
         "1": "Samples that are biological replicates should have the same group name.  If your project does not contain biological replicates, give each sample its own group name."
     },
     "Isotope Label* (required for Stable Isotope Probing samples)": {
-        "1": "Choose from the following: C13, N15, O18, Unlabeled ",
-        "sub_port_mapping": "isotope_exposure"
+        "1": "Choose from the following: C13, N15, O18, Unlabeled "
     },
     "Concentration* (ng/ul)": {
         "1": "Must be calculated using a fluorometric method; value >0 and <2000.",

--- a/input-files/jgi_mg_header_v15.json
+++ b/input-files/jgi_mg_header_v15.json
@@ -31,8 +31,7 @@
     },
     "Isotope Label* (required for Stable Isotope Probing (SIP source samples)": {
         "1": "Choose from the following: C13, N15, O18, Unlabeled",
-        "2": "",
-        "sub_port_mapping": "isotope_exposure"
+        "2": ""
     },
     "Concentration* (ng/ul)": {
         "1": "Must be calculated using a fluorometric method; value >0 and <2000.",

--- a/input-files/jgi_mg_header_v16.json
+++ b/input-files/jgi_mg_header_v16.json
@@ -31,8 +31,7 @@
     },
     "Isotope Label* (required for Stable Isotope Probing (SIP source samples)": {
         "1": "Choose from the following: C13, N15, O18, Unlabeled",
-        "2": "",
-        "sub_port_mapping": "isotope_exposure"
+        "2": ""
     },
     "Isotopolog / PubChem CID* (required for Stable Isotope Probing (SIP source samples)": {
         "1": "Value must be an integer >=0.",

--- a/input-files/jgi_mt_header.json
+++ b/input-files/jgi_mt_header.json
@@ -23,8 +23,7 @@
         "1": "Samples that are biological replicates should have the same group name.  If your project does not contain biological replicates, give each sample its own group name."
     },
     "Isotope Label* (required for Stable Isotope Probing samples)": {
-        "1": "Choose from the following: C13, N15, O18, Unlabeled ",
-        "sub_port_mapping": "isotope_exposure"
+        "1": "Choose from the following: C13, N15, O18, Unlabeled "
     },
     "Concentration* (ng/ul)": {
         "1": "Must be calculated using a fluorometric method; value >0 and <2000.",

--- a/input-files/jgi_mt_header_v15.json
+++ b/input-files/jgi_mt_header_v15.json
@@ -31,8 +31,7 @@
     },
     "Isotope Label* (required for Stable Isotope Probing (SIP source samples)": {
         "1": "Choose from the following: C13, N15, O18, Unlabeled ",
-        "2": "",
-        "sub_port_mapping": "isotope_exposure"
+        "2": ""
     },
     "Concentration* (ng/ul)": {
         "1": "Must be calculated using a fluorometric method; value >0 and <2000.",

--- a/input-files/jgi_mt_header_v16.json
+++ b/input-files/jgi_mt_header_v16.json
@@ -31,8 +31,7 @@
     },
     "Isotope Label* (required for Stable Isotope Probing (SIP source samples)": {
         "1": "Choose from the following: C13, N15, O18, Unlabeled ",
-        "2": "",
-        "sub_port_mapping": "isotope_exposure"
+        "2": ""
     },
     "Isotopolog / PubChem CID* (required for Stable Isotope Probing (SIP source samples)": {
         "1": "Value must be an integer >=0.",


### PR DESCRIPTION
Closes #109 

Ref email thread "JGI CSP project (# 509865)" - Removes the mapping mapping between isotope_exposure and 'Isotope Label*' until NMDC supports JGI's SIP metagenomes. 